### PR TITLE
chore: .editorconfig end_of_line = lf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,7 @@ root = true
 
 [*]
 charset = utf-8
+end_of_line = lf
 indent_style = space
 indent_size = 2
 insert_final_newline = true


### PR DESCRIPTION
I have Windows people's editors still getting confused occasionally.

@web-padawan any objections to standardizing on Unix linefeeds?