### PR TITLE
chore: make `build-styling` cross-platform compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "argos": "argos upload test/visual/screenshots/chrome --token $ARGOS_TOKEN || true",
     "build": "yarn build-styling",
-    "build-styling": "node packages/sass-render/bin/sass-render.js -s 'packages/*/scss/*.scss'",
+    "build-styling": "node packages/sass-render/bin/sass-render.js -s \"packages/*/scss/*.scss\"",
     "deploy-storybook": "yarn --cwd packages/storybook storybook-to-ghpages",
     "dist": "lerna run dist",
     "lint": "npm-run-all --parallel lint:*",


### PR DESCRIPTION
Apparently Windows can only successfully build with escaped or no
double-quotes.

Linux fails to build with no double-quotes, so only given option remains.